### PR TITLE
refactor(metrics): the weight scale measures ownership, so regen-diff costs 1

### DIFF
--- a/docs/harness-metrics.md
+++ b/docs/harness-metrics.md
@@ -314,20 +314,42 @@ Operationally, per benchmark:
 ## Normalizing change difficulty across kinds
 
 Different change kinds are not equally cheap, so the raw count can't be compared
-across benchmarks. Each change is weighted by **how much of it the platform
-absorbed** — the moat, in cost terms (`CHANGE_WEIGHTS` /`changeWeight`):
+across benchmarks. Each change is weighted by **how much ownership it left
+behind** — what stops regenerating, and what the system stops understanding
+about your app (`CHANGE_WEIGHTS` / `changeWeight`):
 
-| Change kind            | Weight | What the maintainer did                                   |
-| ---------------------- | :----: | --------------------------------------------------------- |
-| spec op (`apply-op`)   |   1    | Expressed the change as a typed op; platform generated it |
-| spec op (`regen-diff`) |   2    | Reviewed an agent-produced diff (bet B)                   |
-| slot fill              |   3    | Wrote code into a cross-file extension slot               |
-| eject                  |   5    | Took whole-file ownership; pays the eject tax             |
-| off-surface            |   8    | Built it outside the spec; the platform absorbed none     |
+| Change kind            | Weight | What it left behind                                        |
+| ---------------------- | :----: | ---------------------------------------------------------- |
+| spec op (`apply-op`)   |   1    | Nothing — a typed edit to the spec                         |
+| spec op (`regen-diff`) |   1    | Nothing — a spec edit landed as a reviewed diff (bet B)    |
+| slot fill              |   3    | Code the system can't read, in a file that still regenerates |
+| eject                  |   5    | A whole file that stops regenerating, yours from now on    |
+| off-surface            |   8    | No seam to land in at all; the platform absorbed none      |
 
-The ordering (`op < regen-diff < slot-fill < eject < off-surface`) is the invariant: cheaper =
-more absorbed. The weights are deliberately coarse and will be recalibrated once
-live-`AiClient` runs give real per-kind effort data.
+The ordering (`spec op < slot-fill < eject < off-surface`) is the invariant:
+cheaper = less left outside the system's comprehension.
+
+### Why ownership, and why `regen-diff` moved from 2 to 1
+
+The table used to ask *"how much did the maintainer still do by hand?"* That
+stopped being one question once agents wrote most of the code, because it could
+mean **authoring** (who typed it — now near-free), **review** (real, but paid
+once), or **ownership** (paid every time anyone touches the app afterwards).
+
+It measures ownership, because ownership is what the central claim rests on:
+*still fast on day fifty* is a statement about accumulated ownership, not about
+how long the first edit took.
+
+Read that way the old table was a blend. `apply-op` and `regen-diff` both edit
+the spec — nothing leaves the system either way, so their ownership cost is
+identically zero — yet they were weighted apart. That gap was authoring effort,
+left over from when authoring and ownership rose together. Corrected on
+2026-08-10; `WEIGHT_SCALE.version` is 2, and the frozen corpus baseline stores
+v1 weights, which `changeWeightV1` exists to verify against.
+
+Rungs 3 and up already tracked ownership correctly and are unchanged. So is
+`residualDifficulty` (ejects and off-surface asks only), which means the
+moat-gap bar is unaffected by the recalibration.
 
 ## The iteration-cost headline number: `weightPerSafeChange`
 
@@ -342,8 +364,8 @@ marketing page quotes and an unreproducible figure is worse than none. The
 `regen-diff`), 3 slot fills and 1 eject; its 2 off-surface asks do not land:
 
 ```
-op(1×6) + regen-diff(2) + slot(3×3) + eject(5)   22
-──────────────────────────────────────────────  = ── = 2.00
+op(1×6) + regen-diff(1) + slot(3×3) + eject(5)   21
+──────────────────────────────────────────────  = ── = 1.91
                 11 safe changes                   11
 ```
 

--- a/packages/spec-derive/src/weights.ts
+++ b/packages/spec-derive/src/weights.ts
@@ -6,6 +6,16 @@
  * platform has no seam for costs the most of all. `changeWeight` turns that
  * ordering into a number.
  *
+ * **What the number measures is ownership** — what stops regenerating, and what
+ * the system stops understanding about your app — rather than how long the edit
+ * took to write. Those two used to rise together and no longer do, now that
+ * agents author most changes. Ownership is the one that keeps costing after the
+ * change lands, so it is the one that should sink a candidate in the queue.
+ *
+ * Settled 2026-08-10; the internal corpus scale in `@maxstack/benchmarks` is
+ * kept in step with this table deliberately, since two tables of the same name
+ * disagreeing is worse than either value being wrong.
+ *
  * It lives beside `priority.ts` because that is what consumes it: the review
  * queue divides demand by cost, so an expensive candidate sinks in the product
  * queue precisely because it is expensive.
@@ -14,19 +24,20 @@
 import type { ExampleChange } from './types.ts'
 
 /**
- * Normalized difficulty weight per change kind. The keys are the `kind`
+ * Normalized **ownership** cost per change kind. The keys are the `kind`
  * (`:via` for spec ops) so the table doubles as documentation.
  *
- * A typed spec op costs 1 (fully expressed as an op); a regeneration-as-diff
- * edit costs 2 (agent produced a reviewed diff); a slot fill costs 3 (the user
- * writes code into a slot); an eject costs 5 (the user takes whole-file
- * ownership and pays the eject tax); an off-surface ask costs 8 (the platform
- * gave no op and no slot, so the maintainer was forced off the surface with no
- * guidance — the most expensive class, and the moat gap).
+ * A spec op costs 1 whether it was a typed op or a reviewed regeneration diff —
+ * both edit the spec, and neither leaves anything behind that the system stops
+ * understanding. A slot fill costs 3: code now exists that the system cannot
+ * read, though the file around it still regenerates. An eject costs 5: a whole
+ * file stops regenerating and is yours from then on. An off-surface ask costs 8:
+ * no op and no slot, so there was no seam to land in — the most expensive class,
+ * and the moat gap.
  */
 export const CHANGE_WEIGHTS = {
 	'spec-op:apply-op': 1,
-	'spec-op:regen-diff': 2,
+	'spec-op:regen-diff': 1,
 	'slot-fill': 3,
 	eject: 5,
 	'off-surface': 8,


### PR DESCRIPTION
The per-kind difficulty table asked *"how much of the change did the maintainer still have to do **by hand**?"* That stopped being one question once agents wrote most of the code. "By hand" could mean three things, and they no longer move together:

- **Authoring** — who typed it. Agents collapsed this to near zero.
- **Review** — reading and approving. Real, but paid once.
- **Ownership** — what stops regenerating, and what the system stops understanding about your app. Paid every time anyone touches the app afterwards.

**It measures ownership**, because ownership is what the central claim rests on: *still fast on day fifty* is a statement about accumulated ownership, not about how long the first edit took.

Read that way the old table was a **blend**. `apply-op` (1) and `regen-diff` (2) both edit the spec — nothing leaves the system either way, so their ownership cost is identically zero — yet they were weighted apart. That gap was authoring effort, left over from when authoring and ownership rose together. `regen-diff` is now **1**.

Rungs 3 and up already tracked ownership correctly and are unchanged: a slot fill leaves code the surrounding file still regenerates around, an eject stops regeneration for a whole file, an off-surface ask had no seam at all.

`residualDifficulty` sums ejects and off-surface asks only, both unchanged — so the moat-gap bar is unaffected.

## Product behaviour

`spec-derive`'s table ranks the workbench review queue, so this changes ranking slightly: a `regen-diff` candidate now ranks level with an `apply-op` one. Deliberate — under the ownership reading they cost the same. The internal corpus table moves in step, because two tables of the same name disagreeing is worse than either value being wrong.

## Verification

`spec-derive` 59, `core` 754, `maxstack` 442, `apps/web` workbench 173 — all green. The doc's worked example moves 2.00 → 1.91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)