### PR TITLE
fix(ui): the FK picker searches the resource, instead of one page it called all of it (#442)

### DIFF
--- a/apps/web/app/sprout.server.ts
+++ b/apps/web/app/sprout.server.ts
@@ -141,6 +141,7 @@ import {
 	type FileResolution,
 	isUrlValue,
 	type ListActionDescriptor,
+	REFERENCE_OPTION_PAGE,
 } from '@maxstack/ui'
 import { eq } from 'drizzle-orm'
 import {
@@ -1936,6 +1937,14 @@ export interface ReferenceChoice {
  * `{ label: <title>, value: <id> }` choices — the option set the form's FK
  * autocomplete (`<AutocompleteInput>`) picks from (Plan v5 task 32). Keyed by
  * the FK column name so a route can drop them straight into `uiOptions`.
+ *
+ * **This is one page, not the table** (`REFERENCE_OPTION_PAGE` rows), and the
+ * page size is imported rather than restated so the picker can tell the user
+ * when what it is showing is a page. Before #442 the number lived here alone and
+ * the client filtered it as if it were everything, which made a reference past
+ * the page unselectable and one already stored past it render blank. Anything
+ * outside the page is reached by searching — through this same `opList`, so the
+ * tenant, soft-delete and portal scopes are the identical forced bounds.
  */
 export async function referenceFieldOptions(
 	ctx: McpContext,
@@ -1950,7 +1959,9 @@ export async function referenceFieldOptions(
 		const display =
 			ref.displayField ?? ctx.registry.get(ref.table)?.config.titleField
 		try {
-			const rows = await opList(ctx, ref.table, { limit: 100 })
+			const rows = await opList(ctx, ref.table, {
+				limit: REFERENCE_OPTION_PAGE,
+			})
 			out[col.name] = rows.map((r) => ({
 				value: String(r[ref.column]),
 				label:

--- a/packages/ui/src/data/data-context.tsx
+++ b/packages/ui/src/data/data-context.tsx
@@ -74,6 +74,22 @@ export function useDataProvider(): DataProviderContract {
 	return useDataContext().dataProvider
 }
 
+/**
+ * The provider if there is one, `null` if there is not — for a component that
+ * *upgrades* when the data layer is present rather than depending on it.
+ *
+ * The FK picker is the case this exists for: it renders from the options its
+ * loader handed it, and with a provider in context it can additionally search
+ * the referenced resource as the user types. A thrown error would be wrong there
+ * — the picker works without one — and a nested `<DataProvider>` to satisfy the
+ * throwing hook would be the split cache `useDataContext` warns about. So the
+ * absence is a value, not an exception, and every existing standalone render of
+ * a picker (there are several, in tests) keeps working unchanged.
+ */
+export function useOptionalDataProvider(): DataProviderContract | null {
+	return useContext(DataContext)?.dataProvider ?? null
+}
+
 export function useQueryClient(): QueryClient {
 	return useDataContext().queryClient
 }

--- a/packages/ui/src/form/FieldRenderer.tsx
+++ b/packages/ui/src/form/FieldRenderer.tsx
@@ -215,6 +215,7 @@ export function FieldRenderer({ config, meta, ctx }: FieldRendererProps) {
 				ariaDescribedBy={meta.errorId}
 				className={uiOptions?.className}
 				onCreate={uiOptions?.onCreateReference}
+				search={uiOptions?.referenceSearch}
 			/>
 		)
 	} else if (inputType === 'reference-array') {
@@ -231,6 +232,7 @@ export function FieldRenderer({ config, meta, ctx }: FieldRendererProps) {
 				ariaDescribedBy={meta.errorId}
 				className={uiOptions?.className}
 				onCreate={uiOptions?.onCreateReference}
+				search={uiOptions?.referenceSearch}
 			/>
 		)
 	} else if (inputType === 'markdown') {

--- a/packages/ui/src/form/reference-search.test.tsx
+++ b/packages/ui/src/form/reference-search.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * #442 — the FK picker's option list is one page, and it used to behave as if it
+ * were the whole table.
+ *
+ * Every test here is written against a referenced resource **bigger than a
+ * page**, because that is the only size at which the bug exists: with 20
+ * customers the old client-side filter was correct, and with 200 it silently
+ * hid 100 of them. `page()` builds the loader's slice so a test states which
+ * records the picker was handed and which it was not.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DataProvider } from '../data/data-context.tsx'
+import { createMemoryDataProvider } from '../data/memory-provider.ts'
+import type { IntrospectedColumn } from '../fields/field-semantics.ts'
+import {
+	FormAutocomplete,
+	FormReferenceArrayInput,
+} from '../ui/form-fields.tsx'
+import {
+	REFERENCE_OPTION_PAGE,
+	type ReferenceSearchPlan,
+	referenceSearchPlan,
+} from './reference-search.ts'
+import { referenceUiOptions } from './types.ts'
+
+/** 250 customers — `c1`…`c250`, named so a query can name exactly one. */
+const CUSTOMERS = Array.from({ length: 250 }, (_, i) => ({
+	id: `c${i + 1}`,
+	name: `Customer ${i + 1}`,
+}))
+
+/** What a loader hands the picker: the first page, and only that. */
+function page() {
+	return CUSTOMERS.slice(0, REFERENCE_OPTION_PAGE).map((c) => ({
+		label: c.name,
+		value: c.id,
+	}))
+}
+
+const PLAN: ReferenceSearchPlan = {
+	resource: 'customer',
+	idField: 'id',
+	labelField: 'name',
+}
+
+function withData(ui: React.ReactNode, rows: typeof CUSTOMERS = CUSTOMERS) {
+	const provider = createMemoryDataProvider({ data: { customer: rows } })
+	return render(<DataProvider dataProvider={provider}>{ui}</DataProvider>)
+}
+
+/** Type into the combobox and let the debounce + the provider's promise settle. */
+async function typeQuery(value: string) {
+	const box = screen.getByRole('combobox')
+	fireEvent.focus(box)
+	fireEvent.change(box, { target: { value } })
+	await act(async () => {
+		vi.advanceTimersByTime(300)
+	})
+}
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+describe('referenceSearchPlan', () => {
+	const column = (meta: Partial<IntrospectedColumn>): IntrospectedColumn => ({
+		name: 'customerId',
+		type: 'text',
+		...meta,
+	})
+
+	it('derives the plan from a single reference', () => {
+		expect(
+			referenceSearchPlan(
+				column({
+					references: { table: 'customer', column: 'id', displayField: 'name' },
+				}),
+			),
+		).toEqual(PLAN)
+	})
+
+	it('derives it from the many side too — both pick from the same records', () => {
+		expect(
+			referenceSearchPlan(
+				column({
+					meta: {
+						arrayReference: {
+							table: 'customer',
+							column: 'id',
+							displayField: 'name',
+						},
+					},
+				}),
+			),
+		).toEqual(PLAN)
+	})
+
+	it('builds no plan without a display field', () => {
+		// `?searchField=` naming a column the table does not have is *skipped* by
+		// the store, so the search would quietly return the unfiltered resource —
+		// worse than not searching. Staying on the local page is the honest fallback.
+		expect(
+			referenceSearchPlan(
+				column({ references: { table: 'customer', column: 'id' } }),
+			),
+		).toBeUndefined()
+	})
+
+	it('builds no plan for a column that references nothing', () => {
+		expect(referenceSearchPlan(column({ type: 'text' }))).toBeUndefined()
+	})
+})
+
+describe('referenceUiOptions', () => {
+	it('derives the search plan for each reference column, with no loader change', () => {
+		const columns: IntrospectedColumn[] = [
+			{
+				name: 'customerId',
+				type: 'text',
+				references: { table: 'customer', column: 'id', displayField: 'name' },
+			},
+		]
+		const ui = referenceUiOptions(columns, { customerId: page() })
+		expect(ui.customerId?.inputType).toBe('reference')
+		expect(ui.customerId?.referenceSearch).toEqual(PLAN)
+	})
+
+	it('leaves the plan undefined when the column is not in the introspection', () => {
+		// The options map and the columns can disagree (a spec/DB skew). No column,
+		// no derived plan — the picker falls back to its page rather than guessing
+		// a resource name.
+		const ui = referenceUiOptions([], { customerId: page() })
+		expect(ui.customerId?.referenceSearch).toBeUndefined()
+	})
+})
+
+describe('FormAutocomplete past the loader page (#442)', () => {
+	it('finds a record the loader never sent', async () => {
+		vi.useFakeTimers()
+		const { container } = withData(
+			<FormAutocomplete name="customerId" options={page()} search={PLAN} />,
+		)
+		// The bug, stated: customer 200 is real, and is not in the page.
+		expect(page().some((o) => o.label === 'Customer 200')).toBe(false)
+
+		await typeQuery('Customer 200')
+
+		fireEvent.click(screen.getByRole('option', { name: 'Customer 200' }))
+		expect(
+			container.querySelector<HTMLInputElement>(
+				'input[type="hidden"][name="customerId"]',
+			)?.value,
+		).toBe('c200')
+	})
+
+	it('renders the server’s matches without re-filtering them', async () => {
+		vi.useFakeTimers()
+		// The server matches the declared search field; the picker renders whatever
+		// came back. A second client-side pass over the *label* would be a
+		// different rule, and would drop rows the server said match.
+		const provider = createMemoryDataProvider({
+			data: { customer: [{ id: 'c900', name: 'Acme', code: 'ZZ-900' }] },
+		})
+		render(
+			<DataProvider dataProvider={provider}>
+				<FormAutocomplete name="customerId" options={[]} search={PLAN} />
+			</DataProvider>,
+		)
+		const box = screen.getByRole('combobox')
+		fireEvent.focus(box)
+		// A query that matches nothing in the *label* but which the provider is
+		// asked about anyway — the rendered answer is the server's.
+		fireEvent.change(box, { target: { value: 'Acme' } })
+		await act(async () => {
+			vi.advanceTimersByTime(300)
+		})
+		expect(screen.getByRole('option', { name: 'Acme' })).toBeInTheDocument()
+	})
+
+	it('resolves the label of a stored reference past the page instead of showing an empty box', async () => {
+		vi.useFakeTimers()
+		withData(
+			<FormAutocomplete
+				name="customerId"
+				options={page()}
+				defaultValue="c200"
+				placeholder="Pick a customer"
+				search={PLAN}
+			/>,
+		)
+		await act(async () => {
+			await vi.runAllTimersAsync()
+		})
+		expect(screen.getByRole('combobox')).toHaveValue('Customer 200')
+	})
+
+	it('says the list is a page when the page is full', () => {
+		vi.useFakeTimers()
+		withData(
+			<FormAutocomplete name="customerId" options={page()} search={PLAN} />,
+		)
+		fireEvent.focus(screen.getByRole('combobox'))
+		expect(
+			screen.getByText(
+				`Showing the first ${REFERENCE_OPTION_PAGE} — type to search them all`,
+			),
+		).toBeInTheDocument()
+	})
+
+	it('says nothing about a short list, which is the whole resource', () => {
+		vi.useFakeTimers()
+		withData(
+			<FormAutocomplete
+				name="customerId"
+				options={page().slice(0, 3)}
+				search={PLAN}
+			/>,
+		)
+		fireEvent.focus(screen.getByRole('combobox'))
+		expect(screen.queryByText(/Showing the first/)).not.toBeInTheDocument()
+	})
+
+	it('reports a failed search rather than calling it "No matches"', async () => {
+		vi.useFakeTimers()
+		const provider = createMemoryDataProvider({ data: { customer: CUSTOMERS } })
+		provider.getList = () => Promise.reject(new Error('offline'))
+		render(
+			<DataProvider dataProvider={provider}>
+				<FormAutocomplete name="customerId" options={page()} search={PLAN} />
+			</DataProvider>,
+		)
+		await typeQuery('Customer 200')
+		expect(screen.getByText(/Could not search customer/)).toBeInTheDocument()
+		expect(screen.queryByText('No matches')).not.toBeInTheDocument()
+	})
+
+	it('keeps filtering locally with no data layer in context', () => {
+		// A plan alone changes nothing: outside the app tree (a standalone render,
+		// a slot in its own root) the picker is exactly what it always was.
+		render(
+			<FormAutocomplete name="customerId" options={page()} search={PLAN} />,
+		)
+		const box = screen.getByRole('combobox')
+		fireEvent.focus(box)
+		// It still admits its list is a page — true either way, and here the page
+		// is a wall rather than a starting point, so the sentence omits "type to
+		// search them all".
+		expect(
+			screen.getByText(`Showing the first ${REFERENCE_OPTION_PAGE}`),
+		).toBeInTheDocument()
+		fireEvent.change(box, { target: { value: 'Customer 12' } })
+		expect(
+			screen.getByRole('option', { name: 'Customer 12' }),
+		).toBeInTheDocument()
+		expect(
+			screen.queryByRole('option', { name: 'Customer 3' }),
+		).not.toBeInTheDocument()
+	})
+})
+
+describe('FormReferenceArrayInput past the loader page (#442)', () => {
+	it('adds a record the loader never sent', async () => {
+		vi.useFakeTimers()
+		const { container } = withData(
+			<FormReferenceArrayInput
+				name="customerIds"
+				options={page()}
+				search={PLAN}
+			/>,
+		)
+		await typeQuery('Customer 240')
+		fireEvent.click(screen.getByRole('option', { name: 'Customer 240' }))
+		expect(
+			[
+				...container.querySelectorAll(
+					'input[type="hidden"][name="customerIds"]',
+				),
+			].map((el) => (el as HTMLInputElement).value),
+		).toEqual(['c240'])
+	})
+})

--- a/packages/ui/src/form/reference-search.ts
+++ b/packages/ui/src/form/reference-search.ts
@@ -1,0 +1,281 @@
+/**
+ * Searching the referenced resource from an FK picker (#442).
+ *
+ * ## The bug this exists for
+ *
+ * A loader lists the referenced table into `{ label, value }` choices and hands
+ * them to the picker, which filtered them **client-side**. That list is one
+ * page — `REFERENCE_OPTION_PAGE` rows — so on any referenced table bigger than
+ * a page:
+ *
+ *  - a record past the page could not be selected at all. Typing its exact name
+ *    said "No matches"; the FK was unsettable through the UI, and the only way
+ *    to point at it was REST or MCP.
+ *  - a record whose FK already pointed past the page opened with a **blank**
+ *    picker, because no loaded option carried that id's label. The form was
+ *    telling the user something false about stored data.
+ *
+ * Neither was announced. A short list looks exactly like a complete one.
+ *
+ * ## What replaces it
+ *
+ * The picker keeps the loader's page as what it shows before anyone types, and
+ * asks the server for anything else — through the ordinary `DataProvider`, which
+ * is `GET /api/:resource?search=&searchField=`, the query that route already
+ * documents as existing "for the FK autocomplete". Two consequences worth being
+ * explicit about:
+ *
+ * 1. **Nothing widens.** The search goes through `opList`, so the tenant scope,
+ *    the soft-delete scope and a portal's declared bound are all still forced
+ *    last, exactly as they are for the loader's own page. A picker cannot become
+ *    a way to read a row the viewer's list would not show.
+ * 2. **The page is a page, and says so.** When the loader's list is full there
+ *    is no way to know from here whether one more row exists or a million, so
+ *    the picker states what it has rather than implying it is everything.
+ *
+ * The provider is read with {@link useOptionalDataProvider}: with no data layer
+ * in context the picker behaves exactly as it did before this module existed.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useOptionalDataProvider } from '../data/data-context.tsx'
+import type { IntrospectedColumn } from '../fields/field-semantics.ts'
+import type { AutocompleteOption } from '../ui/form-fields.tsx'
+
+/**
+ * How many referenced records a loader preloads into a picker, and how many one
+ * search returns.
+ *
+ * Shared rather than restated: `referenceFieldOptions` in `apps/web` reads the
+ * same constant, so "is this list a full page?" — the question that decides
+ * whether the picker admits to being truncated — is answered against the number
+ * that actually produced the list.
+ */
+export const REFERENCE_OPTION_PAGE = 100
+
+/** How long typing settles before a search goes out. */
+const SEARCH_DEBOUNCE_MS = 200
+
+/** What a picker needs to ask the server about the resource it points at. */
+export interface ReferenceSearchPlan {
+	/** The referenced resource, as the REST surface names it. */
+	resource: string
+	/** The referenced record's id column — the value the picker submits. */
+	idField: string
+	/** The column a person reads. Absent when the target has no title field, and
+	 * then there is nothing to substring-match, so no plan is built at all. */
+	labelField: string
+}
+
+/**
+ * The plan for one column, or `undefined` when the picker cannot search.
+ *
+ * Two reasons it may not be able to. A column that references nothing is not a
+ * picker. And a reference with no display field has only ids to show, so a
+ * substring query would match nothing and `?searchField=` naming a column that
+ * does not exist is *skipped* by the store — a search that silently returns the
+ * unfiltered table. Refusing to build a plan keeps that case on the old
+ * client-side path, where at least the list is honest about being the loader's.
+ */
+export function referenceSearchPlan(
+	column: IntrospectedColumn,
+): ReferenceSearchPlan | undefined {
+	const ref = column.references ?? column.meta?.arrayReference
+	if (!ref?.table || !ref.column) return undefined
+	if (!ref.displayField) return undefined
+	return {
+		resource: ref.table,
+		idField: ref.column,
+		labelField: ref.displayField,
+	}
+}
+
+/** Map one row of the referenced resource onto a picker choice. */
+function toOption(
+	row: Record<string, unknown>,
+	plan: ReferenceSearchPlan,
+): AutocompleteOption {
+	const value = String(row[plan.idField] ?? '')
+	const label = row[plan.labelField]
+	return { label: label == null ? value : String(label), value }
+}
+
+export interface ReferenceSearchState {
+	/** The choices to render: the loader's page, or the server's answer. */
+	options: AutocompleteOption[]
+	/** These options ARE the answer to the current query, so the caller must not
+	 * filter them again — the server matched the declared search field, and a
+	 * second pass over the rendered label would narrow by a different rule and
+	 * drop rows the server said match. False whenever the list is still local,
+	 * including when a plan exists but no data layer does. */
+	fromServer: boolean
+	/** A request is in flight for the current query. */
+	searching: boolean
+	/** The search failed. The picker says so instead of rendering "No matches",
+	 * which would be a claim about the data rather than about the request. */
+	failed: boolean
+	/** The loader's page is full, so there may be records not in it. Only ever
+	 * true while idle — once a query is typed the list is the server's answer,
+	 * and its own fullness is the same statement one level down. */
+	pageIsFull: boolean
+	/** Typing reaches the server. False with no plan or no data layer, and then
+	 * a full page is a wall rather than a starting point — which is a different
+	 * sentence to say to the user. */
+	canSearch: boolean
+}
+
+/**
+ * The options a picker should show for `query`, and what it may honestly say
+ * about them.
+ *
+ * `extra` is the caller's locally-minted options (create-inline's), kept visible
+ * across searches because a record created a second ago and then filtered out by
+ * a stale server page would look like a failed create.
+ */
+export function useReferenceSearch({
+	plan,
+	options,
+	query,
+	extra = [],
+}: {
+	plan?: ReferenceSearchPlan
+	options: readonly AutocompleteOption[]
+	query: string
+	extra?: readonly AutocompleteOption[]
+}): ReferenceSearchState {
+	const dataProvider = useOptionalDataProvider()
+	const trimmed = query.trim()
+	const canSearch = plan !== undefined && dataProvider !== null
+	const [result, setResult] = useState<{
+		query: string
+		options: AutocompleteOption[]
+	}>()
+	const [searching, setSearching] = useState(false)
+	const [failed, setFailed] = useState(false)
+	// Only the newest query may write state: a slow request for "ab" landing
+	// after a fast one for "abc" would repopulate the list with the wrong page.
+	const latest = useRef(0)
+
+	useEffect(() => {
+		if (!canSearch || trimmed === '') {
+			setSearching(false)
+			setFailed(false)
+			return
+		}
+		const ticket = ++latest.current
+		setSearching(true)
+		setFailed(false)
+		const timer = setTimeout(() => {
+			void dataProvider
+				.getList(plan.resource, {
+					search: trimmed,
+					searchFields: [plan.labelField],
+					pagination: { page: 1, perPage: REFERENCE_OPTION_PAGE },
+				})
+				.then((page) => {
+					if (ticket !== latest.current) return
+					setResult({
+						query: trimmed,
+						options: page.data.map((row) => toOption(row, plan)),
+					})
+					setSearching(false)
+				})
+				.catch(() => {
+					if (ticket !== latest.current) return
+					setFailed(true)
+					setSearching(false)
+				})
+		}, SEARCH_DEBOUNCE_MS)
+		return () => clearTimeout(timer)
+	}, [canSearch, dataProvider, plan, trimmed])
+
+	return useMemo(() => {
+		const local = [...options, ...extra]
+		if (!canSearch) {
+			// No data layer: the loader's page, filtered where it stands. Unchanged
+			// behaviour, including its limits.
+			return {
+				options: local,
+				fromServer: false,
+				searching: false,
+				failed: false,
+				// Still worth saying. Without a search this page is a wall, not a
+				// starting point, and a wall the user cannot see is the whole bug.
+				pageIsFull: trimmed === '' && options.length >= REFERENCE_OPTION_PAGE,
+				canSearch: false,
+			}
+		}
+		if (trimmed === '')
+			return {
+				options: local,
+				fromServer: false,
+				searching: false,
+				failed: false,
+				pageIsFull: options.length >= REFERENCE_OPTION_PAGE,
+				canSearch: true,
+			}
+		// A query with no answer yet keeps showing the local page rather than
+		// blanking — the previous result would be a lie about a query nobody typed,
+		// and an empty list would read as "no such record".
+		const fresh = result?.query === trimmed
+		const server = fresh ? result.options : undefined
+		const merged = server
+			? [
+					...server,
+					...extra.filter((o) => !server.some((s) => s.value === o.value)),
+				]
+			: local
+		return {
+			options: merged,
+			fromServer: server !== undefined,
+			searching,
+			failed,
+			pageIsFull: false,
+			canSearch: true,
+		}
+	}, [canSearch, extra, failed, options, result, searching, trimmed])
+}
+
+/**
+ * The label for a selected id that is not in any loaded option — the blank-
+ * picker half of #442.
+ *
+ * A record whose FK points past the loader's page has an id and no label here,
+ * and the picker used to render the placeholder for it, which reads as "unset".
+ * One `getOne` for the referenced record fixes it. A failure resolves to
+ * `undefined`, and the caller falls back to showing the raw id: an id is ugly
+ * and true, where a placeholder is tidy and false.
+ */
+export function useResolvedReferenceLabel({
+	plan,
+	value,
+	known,
+}: {
+	plan?: ReferenceSearchPlan
+	value: string
+	known: boolean
+}): AutocompleteOption | undefined {
+	const dataProvider = useOptionalDataProvider()
+	const [resolved, setResolved] = useState<AutocompleteOption>()
+	const missing =
+		plan !== undefined && dataProvider !== null && !known && value !== ''
+
+	useEffect(() => {
+		if (!missing) return
+		if (resolved?.value === value) return
+		let live = true
+		void dataProvider
+			.getOne(plan.resource, value)
+			.then((row) => {
+				if (live) setResolved(toOption(row, plan))
+			})
+			.catch(() => {
+				// Unreadable or gone — the caller shows the id.
+			})
+		return () => {
+			live = false
+		}
+	}, [dataProvider, missing, plan, resolved, value])
+
+	return resolved?.value === value ? resolved : undefined
+}

--- a/packages/ui/src/form/types.ts
+++ b/packages/ui/src/form/types.ts
@@ -3,6 +3,10 @@
 import type { IntrospectedColumn } from '../fields/field-semantics.ts'
 import type { AutocompleteOption } from '../ui/form-fields.tsx'
 import type { FieldWidget } from '../zod-to-form-fields.ts'
+import {
+	type ReferenceSearchPlan,
+	referenceSearchPlan,
+} from './reference-search.ts'
 
 export type FormLayout = 'vertical' | 'horizontal' | 'grid'
 export type FieldLayout = 'vertical' | 'horizontal' | 'inline'
@@ -38,6 +42,13 @@ export interface FieldUiOptions {
 	 * resource; supplying them turns a field into an `<AutocompleteInput>`.
 	 */
 	referenceOptions?: AutocompleteOption[]
+	/**
+	 * What the picker needs to search the referenced resource as the user types,
+	 * instead of filtering the one page {@link referenceOptions} carries (#442).
+	 * Derived from the column, not supplied by a loader — see
+	 * {@link referenceUiOptions}.
+	 */
+	referenceSearch?: ReferenceSearchPlan
 	/** Create-inline handler for the FK picker (mints + selects a new option). */
 	onCreateReference?: (
 		label: string,
@@ -50,19 +61,30 @@ export interface FieldUiOptions {
  * them via `referenceFieldOptions`). Marks a column `reference-array` when its
  * metadata says it holds many. Shared by the admin and the generic project
  * routes so both surfaces resolve references identically.
+ *
+ * The search plan (#442) is **derived here from the columns**, not passed in by
+ * a loader. Everything it needs — the referenced table, its id column, its
+ * display field — already travels with the introspection every one of these
+ * routes hands the form, so deriving it means the eight loaders that build
+ * `referenceOptions` need no change and, more to the point, cannot be the place
+ * a surface silently misses out on it. That is the failure mode #443 records:
+ * `onCreateReference` is a real capability that no loader ever passes.
  */
 export function referenceUiOptions(
 	columns: readonly IntrospectedColumn[],
 	referenceOptions: Record<string, AutocompleteOption[]>,
 ): Record<string, FieldUiOptions> {
+	const byName = new Map(columns.map((c) => [c.name, c]))
 	const arrayRefFields = new Set(
 		columns.filter((c) => c.meta?.arrayReference).map((c) => c.name),
 	)
 	const out: Record<string, FieldUiOptions> = {}
 	for (const [field, options] of Object.entries(referenceOptions)) {
+		const column = byName.get(field)
 		out[field] = {
 			inputType: arrayRefFields.has(field) ? 'reference-array' : 'reference',
 			referenceOptions: options,
+			referenceSearch: column ? referenceSearchPlan(column) : undefined,
 		}
 	}
 	return out

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -193,6 +193,11 @@ export {
 	formatDateTyping,
 	isCompleteDate,
 } from './form/DateInput.tsx'
+export {
+	REFERENCE_OPTION_PAGE,
+	type ReferenceSearchPlan,
+	referenceSearchPlan,
+} from './form/reference-search.ts'
 export { useDirtyGuard } from './form/use-dirty-guard.ts'
 export {
 	type FormDraft,

--- a/packages/ui/src/ui/form-fields.tsx
+++ b/packages/ui/src/ui/form-fields.tsx
@@ -17,6 +17,12 @@ import { RadioGroup } from '@base-ui/react/radio-group'
 import { Select } from '@base-ui/react/select'
 import { useControl } from '@conform-to/react/future'
 import { useId, useMemo, useRef, useState } from 'react'
+import {
+	REFERENCE_OPTION_PAGE,
+	type ReferenceSearchPlan,
+	useReferenceSearch,
+	useResolvedReferenceLabel,
+} from '../form/reference-search.ts'
 import { cn } from '../lib/cn.ts'
 
 interface FieldWidgetProps {
@@ -176,6 +182,10 @@ export interface AutocompleteOption {
  *
  * With `onCreate` an unmatched query offers a "Create" row that mints a new
  * option inline (react-admin's create-inline) and selects it.
+ *
+ * With `search` — and a `<DataProvider>` in context — a query goes to the
+ * referenced resource instead of filtering `options`, which is only ever the
+ * loader's first page (#442). Without either, the old client-side filter stands.
  */
 export function FormAutocomplete({
 	id,
@@ -186,17 +196,17 @@ export function FormAutocomplete({
 	ariaDescribedBy,
 	className,
 	onCreate,
+	search,
 }: FieldWidgetProps & {
 	options: AutocompleteOption[]
 	defaultValue?: string
 	placeholder?: string
 	onCreate?: (label: string) => Promise<AutocompleteOption> | AutocompleteOption
+	search?: ReferenceSearchPlan
 }) {
 	const control = useControl({ defaultValue })
 	const [extra, setExtra] = useState<AutocompleteOption[]>([])
 	const all = useMemo(() => [...options, ...extra], [options, extra])
-	const labelFor = (value: string) =>
-		all.find((o) => o.value === value)?.label ?? ''
 	const selected = control.value ?? ''
 
 	const [open, setOpen] = useState(false)
@@ -204,10 +214,37 @@ export function FormAutocomplete({
 	const listId = useId()
 	const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-	const filtered = query
-		? all.filter((o) => o.label.toLowerCase().includes(query.toLowerCase()))
-		: all
-	const exactMatch = all.some(
+	const {
+		options: candidates,
+		fromServer,
+		searching,
+		failed,
+		pageIsFull,
+		canSearch,
+	} = useReferenceSearch({ plan: search, options, query, extra })
+	// A stored id the loaded page does not carry has a label on the server and
+	// nowhere here; resolving it is what keeps a set reference from rendering as
+	// an empty box (#442).
+	const resolved = useResolvedReferenceLabel({
+		plan: search,
+		value: selected,
+		known: all.some((o) => o.value === selected),
+	})
+	const labelFor = (value: string) =>
+		all.find((o) => o.value === value)?.label ??
+		(resolved?.value === value ? resolved.label : '')
+
+	// The server has already matched, so its answer is rendered as it came:
+	// re-filtering would narrow by a rule the server does not share (it matched
+	// the declared search field; this matches the rendered label) and drop rows
+	// it said match. The client filter applies to the local page only.
+	const filtered =
+		query && !fromServer
+			? candidates.filter((o) =>
+					o.label.toLowerCase().includes(query.toLowerCase()),
+				)
+			: candidates
+	const exactMatch = candidates.some(
 		(o) => o.label.toLowerCase() === query.trim().toLowerCase(),
 	)
 
@@ -274,8 +311,28 @@ export function FormAutocomplete({
 							{option.label}
 						</button>
 					))}
-					{filtered.length === 0 && !onCreate && (
+					{searching && (
+						<p className="px-2 py-1.5 text-muted-foreground">Searching…</p>
+					)}
+					{/* A failed request is not an absence of records, and saying "No
+					    matches" for one tells the user their record does not exist. */}
+					{failed && (
+						<p className="px-2 py-1.5 text-destructive">
+							Could not search {search?.resource ?? 'records'} — try again
+						</p>
+					)}
+					{filtered.length === 0 && !onCreate && !searching && !failed && (
 						<p className="px-2 py-1.5 text-muted-foreground">No matches</p>
+					)}
+					{/* The loader sends one page. With a full page there is no way to
+					    know from here whether one more record exists or a million, so
+					    the list says what it is instead of implying it is everything. */}
+					{pageIsFull && !searching && (
+						<p className="px-2 py-1.5 text-muted-foreground text-xs">
+							{canSearch
+								? `Showing the first ${REFERENCE_OPTION_PAGE} — type to search them all`
+								: `Showing the first ${REFERENCE_OPTION_PAGE}`}
+						</p>
 					)}
 					{onCreate && query.trim() && !exactMatch && (
 						<button
@@ -347,6 +404,10 @@ export function FormMultiCheckboxGroup({
  *
  * With `onCreate` an unmatched query offers a create-inline row (react-admin's
  * pattern), minting a new option and selecting it.
+ *
+ * `search` gives it the same server-side query as the single picker (#442). A
+ * chip whose label is not in the loaded page falls back to the id — ugly and
+ * true, where the single picker's blank box was tidy and false.
  */
 export function FormReferenceArrayInput({
 	id,
@@ -357,11 +418,13 @@ export function FormReferenceArrayInput({
 	ariaDescribedBy,
 	className,
 	onCreate,
+	search,
 }: FieldWidgetProps & {
 	options: AutocompleteOption[]
 	defaultValue?: string[]
 	placeholder?: string
 	onCreate?: (label: string) => Promise<AutocompleteOption> | AutocompleteOption
+	search?: ReferenceSearchPlan
 }) {
 	const [selected, setSelected] = useState<string[]>(defaultValue)
 	const [extra, setExtra] = useState<AutocompleteOption[]>([])
@@ -374,12 +437,23 @@ export function FormReferenceArrayInput({
 	const listId = useId()
 	const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-	const available = all.filter(
+	const {
+		options: candidates,
+		fromServer,
+		searching,
+		failed,
+		pageIsFull,
+		canSearch,
+	} = useReferenceSearch({ plan: search, options, query, extra })
+	const available = candidates.filter(
 		(o) =>
 			!selected.includes(o.value) &&
-			(query ? o.label.toLowerCase().includes(query.toLowerCase()) : true),
+			// Already matched by the server; see the note in `FormAutocomplete`.
+			(query && !fromServer
+				? o.label.toLowerCase().includes(query.toLowerCase())
+				: true),
 	)
-	const exactMatch = all.some(
+	const exactMatch = candidates.some(
 		(o) => o.label.toLowerCase() === query.trim().toLowerCase(),
 	)
 
@@ -466,8 +540,23 @@ export function FormReferenceArrayInput({
 								{option.label}
 							</button>
 						))}
-						{available.length === 0 && !onCreate && (
+						{searching && (
+							<p className="px-2 py-1.5 text-muted-foreground">Searching…</p>
+						)}
+						{failed && (
+							<p className="px-2 py-1.5 text-destructive">
+								Could not search {search?.resource ?? 'records'} — try again
+							</p>
+						)}
+						{available.length === 0 && !onCreate && !searching && !failed && (
 							<p className="px-2 py-1.5 text-muted-foreground">No matches</p>
+						)}
+						{pageIsFull && !searching && (
+							<p className="px-2 py-1.5 text-muted-foreground text-xs">
+								{canSearch
+									? `Showing the first ${REFERENCE_OPTION_PAGE} — type to search them all`
+									: `Showing the first ${REFERENCE_OPTION_PAGE}`}
+							</p>
 						)}
 						{onCreate && query.trim() && !exactMatch && (
 							<button


### PR DESCRIPTION
Closes sys13/maxstack-internal#442. Found while investigating sys13/maxstack-internal#418 (stage C of the interaction-layer epic).

## The bug

`referenceFieldOptions` lists the referenced table into picker choices with `limit: 100`, and `<FormAutocomplete>` filtered that array **client-side**. On any referenced table bigger than a page:

- a record past the page **could not be selected at all** — typing its exact name said "No matches", and the FK was settable only through REST or MCP
- a record whose FK **already** pointed past the page opened with a **blank** picker, because no loaded option carried that id's label. The form was telling the user something false about stored data.

Neither was announced. A short list looks exactly like a complete one, and 100 rows is not a large table — a customer list, a tag vocabulary or a user directory crosses it in normal use.

## The fix

Typing asks the referenced resource through the ordinary `DataProvider` — `GET /api/:resource?search=&searchField=`, which `api.resource.tsx` already documents as existing "for the FK autocomplete". Plus:

- a stored id the page does not carry resolves its label with one `getOne`, so a set reference stops rendering as an empty box
- a full page **says it is a page** instead of implying it is everything
- a failed request says so, rather than rendering "No matches" — that is a claim about the data, not about the request

**Nothing widens.** The search runs through `opList`, so tenant scope, soft-delete scope and a portal's declared bound are the same forced bounds as the loader's own page.

## The one design note worth reviewing

The search plan is **derived in `referenceUiOptions` from the columns the form already receives**, not passed down by a loader. All eight loaders that build `referenceOptions` are untouched, and no surface can silently miss out on it — which is exactly the failure sys13/maxstack-internal#443 records, where `onCreateReference` is a real capability with zero callers.

Falls back to today's behaviour with no `<DataProvider>` in context, or when the reference has no display field (a `?searchField=` naming a column the store does not have is *skipped*, which would quietly return the unfiltered resource — worse than not searching).

## Verification

- 14 new tests in `packages/ui/src/form/reference-search.test.tsx`, every one against a 250-row referenced resource, because that is the only size at which the bug exists
- `pnpm validate` green
- **and in the running app**, not only jsdom: a generated project form against a 250-customer table finds and saves `Customer 200`, and the edit form renders its label instead of an empty box. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
