### PR TITLE
feat(ui,web): create the referenced record from the picker, which was built and wired to nothing (#443)

### DIFF
--- a/apps/web/app/reference-create.test.ts
+++ b/apps/web/app/reference-create.test.ts
@@ -1,0 +1,214 @@
+/**
+ * The two gates on create-inline in the FK picker (#443).
+ *
+ * The picker's behaviour once it has a plan is tested in `@maxstack/ui`. What
+ * can only be tested here is the *decision* — because both halves of it are
+ * facts about a resource the form is not for, and a wrong answer either way is a
+ * defect with a name:
+ *
+ *  - too permissive, and the "Create …" row appears for a viewer whose click
+ *    403s, or mints a half-record that 422s. An affordance that promises and
+ *    then refuses is the #388 shape.
+ *  - too restrictive, and a capability silently withdraws itself with nowhere to
+ *    look — which is the state #443 found the whole feature in.
+ *
+ * The `requiredCreateFields` case gets the most attention because it is the one
+ * that drifts: it is a derivation from the create schema, and the schema is
+ * edited by people who have never heard of this file.
+ */
+
+import type { SproutUser } from '@maxstack/core'
+import { ResourceRegistry } from '@maxstack/core'
+import { article, author, comment, tag, task } from '@maxstack/core/demo'
+import { integer, pgTable, text, uuid } from 'drizzle-orm/pg-core'
+import { beforeAll, describe, expect, it } from 'vitest'
+import {
+	getSprout,
+	referenceCreatePlan,
+	referenceFieldOptions,
+} from './sprout.server'
+
+const signedIn: SproutUser = { id: 'u1', role: 'user' }
+
+/** A registry with one resource in it, so a gate can be asked in isolation. */
+function registryOf(
+	table: Parameters<ResourceRegistry['register']>[0],
+	config: Parameters<ResourceRegistry['register']>[1] = {},
+) {
+	const registry = new ResourceRegistry()
+	registry.register(table, config)
+	return registry
+}
+
+const ask = (
+	registry: ResourceRegistry,
+	table: string,
+	display: string | undefined,
+	user: SproutUser | null = signedIn,
+) =>
+	referenceCreatePlan(
+		{ registry, user } as Parameters<typeof referenceCreatePlan>[0],
+		table,
+		'id',
+		display,
+	)
+
+describe('gate 1 — may this viewer create one', () => {
+	it('offers create to a viewer the target admits', async () => {
+		const registry = registryOf(author, {
+			titleField: 'name',
+			access: { read: 'public', create: 'authenticated' },
+		})
+		expect(await ask(registry, 'author', 'name')).toEqual({
+			resource: 'author',
+			idField: 'id',
+			labelField: 'name',
+		})
+	})
+
+	it('withholds it from a viewer who may read the target but not write it', async () => {
+		// The permission the issue turns on. Reading a customer list to pick from
+		// and creating a customer are different grants, and the parent form's
+		// permission is not the one that counts.
+		const registry = registryOf(author, {
+			titleField: 'name',
+			access: { read: 'public', create: 'authenticated' },
+		})
+		expect(await ask(registry, 'author', 'name', null)).toBeUndefined()
+	})
+
+	it('withholds it from an api-key identity outside its scope', async () => {
+		// Not a rule of this module — `canPerformAction` runs the api-key scope gate
+		// before the resource's own rule, closed by default. Pinned here because the
+		// affordance must inherit every narrowing the write does, not just the one
+		// this file happens to know the name of.
+		const registry = registryOf(author, {
+			titleField: 'name',
+			access: { read: 'public', create: 'public' },
+		})
+		const keyed: SproutUser = {
+			id: 'k1',
+			role: 'user',
+			apiKeyScope: { author: ['read'] },
+		}
+		expect(await ask(registry, 'author', 'name', keyed)).toBeUndefined()
+	})
+
+	it('offers nothing for a resource the registry does not have', async () => {
+		expect(await ask(new ResourceRegistry(), 'ghost', 'name')).toBeUndefined()
+	})
+})
+
+describe('gate 2 — is a name enough to make one', () => {
+	it('offers create when the label is the only thing required', async () => {
+		// `tag` is the shape the affordance exists for: one required field, and the
+		// typed string is it.
+		const registry = registryOf(tag, { titleField: 'name' })
+		expect(await ask(registry, 'tag', 'name')).toBeDefined()
+	})
+
+	it('offers it when everything else defaults or is nullable', async () => {
+		// `task` requires only `title`; `done` and `priority` default, `authorId` is
+		// nullable, `createdAt` is a defaulted timestamp the schema drops. A rule
+		// that counted columns rather than reading the create schema would refuse
+		// this one, and refuse most real entities with it.
+		const registry = registryOf(task, { titleField: 'title' })
+		expect(await ask(registry, 'task', 'title')).toBeDefined()
+	})
+
+	it('withholds it when the target requires a second field', async () => {
+		// Minting from a single string here writes a half-record or 422s. Neither is
+		// something to put behind a one-click affordance, so the row is absent.
+		const invoice = pgTable('invoice', {
+			id: uuid('id').primaryKey().defaultRandom(),
+			label: text('label').notNull(),
+			amountCents: integer('amountCents').notNull(),
+		})
+		const registry = registryOf(invoice, { titleField: 'label' })
+		expect(await ask(registry, 'invoice', 'label')).toBeUndefined()
+	})
+
+	it('does not count the columns opCreate stamps after the caller', async () => {
+		// The tenant column is required of the *row* and never of the caller —
+		// `opCreate` overwrites whatever a client sent with the active org. Counting
+		// it as outstanding would withdraw create-inline from every org-scoped
+		// resource in the product, which is nearly all of them.
+		const note = pgTable('note', {
+			id: uuid('id').primaryKey().defaultRandom(),
+			title: text('title').notNull(),
+			orgId: text('orgId').notNull(),
+		})
+		const registry = registryOf(note, {
+			titleField: 'title',
+			tenantField: 'orgId',
+		})
+		expect(await ask(registry, 'note', 'title')).toBeDefined()
+	})
+
+	it('offers nothing when there is no field a name could become', async () => {
+		// No title field: the typed string has nowhere to go, so "create from what
+		// you typed" is not a coherent offer.
+		const registry = registryOf(article, { titleField: 'title' })
+		expect(await ask(registry, 'article', undefined)).toBeUndefined()
+	})
+})
+
+describe('referenceFieldOptions carries the decision to the right column', () => {
+	it('plans create for the FK columns that qualify, beside their options', async () => {
+		const { registry, store } = await getSprout()
+		const plans = await referenceFieldOptions(
+			{ registry, store, user: signedIn } as never,
+			registry.get('task')?.resource as never,
+		)
+		// `task.authorId` points at `author`, which a signed-in viewer may create
+		// and which needs only its name.
+		expect(plans.create.authorId).toEqual({
+			resource: 'author',
+			idField: 'id',
+			labelField: 'name',
+		})
+		// And the options half is untouched by any of this.
+		expect(plans.options.authorId).toBeDefined()
+	})
+
+	it('plans nothing for an anonymous viewer, while still listing the options', async () => {
+		// The asymmetry is the point: `author` reads `public` and creates
+		// `authenticated`, so an anonymous form can pick an author and is not
+		// offered the chance to invent one.
+		const { registry, store } = await getSprout()
+		const plans = await referenceFieldOptions(
+			{ registry, store, user: null } as never,
+			registry.get('task')?.resource as never,
+		)
+		expect(plans.create.authorId).toBeUndefined()
+		expect(plans.options.authorId).toBeDefined()
+	})
+
+	it('plans create for the many side too', async () => {
+		// `article.tags` is an array reference; both sides pick from the same
+		// records, so both sides create into the same resource.
+		const { registry, store } = await getSprout()
+		const plans = await referenceFieldOptions(
+			{ registry, store, user: signedIn } as never,
+			registry.get('article')?.resource as never,
+		)
+		expect(plans.create.tags?.resource).toBe('tag')
+	})
+})
+
+describe('a soft-deleting target', () => {
+	it('is not disqualified by its own deletedAt column', async () => {
+		// Server-stamped `null` on create, exactly like the tenant column.
+		const registry = registryOf(comment, {
+			titleField: 'body',
+			softDelete: true,
+		})
+		expect(await ask(registry, 'comment', 'body')).toBeDefined()
+	})
+})
+
+beforeAll(async () => {
+	// The integration block reads the app's own registry + store; touching it once
+	// up front keeps the first assertion from paying the boot.
+	await getSprout()
+})

--- a/apps/web/app/routes/admin.resource.parse.server.ts
+++ b/apps/web/app/routes/admin.resource.parse.server.ts
@@ -35,7 +35,10 @@ export async function action({ request, params }: AdminResourceArgs) {
 		text,
 		// The same rows the form's comboboxes load, read through this request's
 		// context so a reference the caller may not read yields no options.
-		referenceOptions: await referenceFieldOptions(ctx, entry.resource),
+		// `.options` — the AI extractor resolves a label to an id and never
+		// creates, so the create plans travelling beside them are not its business.
+		referenceOptions: (await referenceFieldOptions(ctx, entry.resource))
+			.options,
 	})
 	if ('error' in result) {
 		return data(result, { status: result.error === 'unparseable' ? 502 : 503 })

--- a/apps/web/app/routes/admin.resource.tsx
+++ b/apps/web/app/routes/admin.resource.tsx
@@ -175,7 +175,7 @@ export default function ResourceListPage({
 						preventScrollReset: true,
 					})
 				}
-				referenceOptions={referenceOptions}
+				referenceOptions={referenceOptions.options}
 				className="mb-4"
 			/>
 

--- a/apps/web/app/routes/project.action-refusals.test.ts
+++ b/apps/web/app/routes/project.action-refusals.test.ts
@@ -59,7 +59,7 @@ vi.mock('~/project.server', () => ({
 
 vi.mock('~/sprout.server', () => ({
 	getContext: async () => ({}),
-	referenceFieldOptions: async () => ({}),
+	referenceFieldOptions: async () => ({ options: {}, create: {} }),
 	relatedRecords: async () => [],
 	resolveRowFiles: () => ({}),
 }))

--- a/apps/web/app/routes/project.page.server.ts
+++ b/apps/web/app/routes/project.page.server.ts
@@ -32,6 +32,7 @@ import {
 	getSprout,
 	hasDemoData,
 	listActionDescriptors,
+	NO_REFERENCE_PLANS,
 	referenceFieldOptions,
 	resolveCapabilities,
 	resolveRowFiles,
@@ -206,7 +207,9 @@ export async function loader({ request, params }: ProjectRouteArgs) {
 		// thing a facet cannot derive from the schema alone. Skipped entirely when
 		// the page shows no FK column, so an ordinary list does not pay a query
 		// for a control it will not render.
-		referenceOptions: view ? {} : await referenceFieldOptions(ctx, shown),
+		referenceOptions: view
+			? NO_REFERENCE_PLANS
+			: await referenceFieldOptions(ctx, shown),
 		// What this session may do to this resource (task 22/35). The server
 		// enforces it either way — `opUpdate` is the wall, not this — but a list
 		// that offers an inline editor to a viewer whose every save will 403 is a

--- a/apps/web/app/routes/project.page.tsx
+++ b/apps/web/app/routes/project.page.tsx
@@ -697,7 +697,7 @@ export default function ProjectListPage({
 			rows={rows}
 			value={filters}
 			references={references}
-			referenceOptions={referenceOptions}
+			referenceOptions={referenceOptions.options}
 			onChange={(next) =>
 				setSearchParams(
 					{ ...filtersToSearchParams(next), ...sortToSearchParams(sort) },

--- a/apps/web/app/routes/project.parse.server.ts
+++ b/apps/web/app/routes/project.parse.server.ts
@@ -26,7 +26,9 @@ export async function action({ request, params }: ProjectRouteArgs) {
 		// resolve to Dana's id. Read through the request's own
 		// context, so a reference the caller may not read yields no options
 		// rather than leaking labels past the permission layer.
-		referenceOptions: await referenceFieldOptions(ctx, resolved.introspection),
+		// `.options` — see the note in the admin's parse route.
+		referenceOptions: (await referenceFieldOptions(ctx, resolved.introspection))
+			.options,
 	})
 	if ('error' in result) {
 		return data(result, { status: result.error === 'unparseable' ? 502 : 503 })

--- a/apps/web/app/sprout.server.ts
+++ b/apps/web/app/sprout.server.ts
@@ -21,6 +21,7 @@ import {
 	AUTHENTICATED_WRITES,
 	applyComputed,
 	type ComputedShape,
+	canPerformAction,
 	createAccessContext,
 	createSpecStore,
 	type InverseReference,
@@ -36,6 +37,7 @@ import {
 	type Row,
 	registerSpecEntities,
 	relatedOrder,
+	requiredCreateFields,
 	resolveReferences,
 	resolveRollups,
 	resourceCapabilities,
@@ -142,6 +144,8 @@ import {
 	isUrlValue,
 	type ListActionDescriptor,
 	REFERENCE_OPTION_PAGE,
+	type ReferenceCreatePlan,
+	type ReferenceFieldPlans,
 } from '@maxstack/ui'
 import { eq } from 'drizzle-orm'
 import {
@@ -1945,12 +1949,18 @@ export interface ReferenceChoice {
  * the page unselectable and one already stored past it render blank. Anything
  * outside the page is reached by searching — through this same `opList`, so the
  * tenant, soft-delete and portal scopes are the identical forced bounds.
+ *
+ * It also answers, per column, whether the picker may offer **create-inline**
+ * (#443) — see {@link referenceCreatePlan}. That answer rides along with the
+ * options rather than arriving by its own optional argument, because an optional
+ * extra a loader may decline to pass is precisely how `onCreateReference` stayed
+ * dead in every generated app for a year while being fully implemented.
  */
 export async function referenceFieldOptions(
 	ctx: McpContext,
 	introspection: SproutResource,
-): Promise<Record<string, ReferenceChoice[]>> {
-	const out: Record<string, ReferenceChoice[]> = {}
+): Promise<ReferenceFieldPlans> {
+	const out: ReferenceFieldPlans = { options: {}, create: {} }
 	for (const col of introspection.columns) {
 		// Single FK or the "many" side (an array reference, task 38) — both pick
 		// from the same option set (the referenced table's records).
@@ -1958,11 +1968,13 @@ export async function referenceFieldOptions(
 		if (!ref) continue
 		const display =
 			ref.displayField ?? ctx.registry.get(ref.table)?.config.titleField
+		const plan = await referenceCreatePlan(ctx, ref.table, ref.column, display)
+		if (plan) out.create[col.name] = plan
 		try {
 			const rows = await opList(ctx, ref.table, {
 				limit: REFERENCE_OPTION_PAGE,
 			})
-			out[col.name] = rows.map((r) => ({
+			out.options[col.name] = rows.map((r) => ({
 				value: String(r[ref.column]),
 				label:
 					display && r[display] != null
@@ -1972,10 +1984,82 @@ export async function referenceFieldOptions(
 		} catch {
 			// An unreadable/unknown referenced table just yields no options rather
 			// than failing the whole page.
-			out[col.name] = []
+			out.options[col.name] = []
 		}
 	}
 	return out
+}
+
+/** No FK columns, so nothing to resolve — the shape a caller that skipped the
+ * resolution passes on. Named rather than written as `{ options: {}, create: {} }`
+ * at each site so a third key added here reaches every one of them. */
+export const NO_REFERENCE_PLANS: ReferenceFieldPlans = {
+	options: {},
+	create: {},
+}
+
+/**
+ * Whether an FK picker may offer to create the record it points at, and what it
+ * needs to do so (#443) — or `undefined`, which is how the affordance stays off
+ * the screen entirely rather than being refused on click.
+ *
+ * Three questions, all about a resource the *form* is not for, which is why they
+ * are answered here and not derived on the client:
+ *
+ * 1. **Is there one field a name can become?** No title field means minting from
+ *    a typed string is meaningless, so there is nothing to offer.
+ * 2. **May this viewer create one?** Asked of `canPerformAction` — the same
+ *    function `authorize()` calls inside `opCreate` — so the row is absent under
+ *    exactly the conditions the write would be refused under. A viewer who may
+ *    pick a customer is not thereby a viewer who may create one.
+ * 3. **Is a name enough?** Every other field the target requires at create must
+ *    have a default or be nullable, or minting writes a half-record or 422s. The
+ *    required set is read from the create schema itself
+ *    (`requiredCreateFields`), minus the columns `opCreate` stamps *after* the
+ *    caller is done — the tenant column and the soft-delete column are required
+ *    of the row and never of the caller, and treating them as caller-facing would
+ *    withdraw create-inline from every org-scoped resource in the product.
+ *
+ * A portal identity is excluded outright. Its writes are declared field-by-field
+ * and budgeted, so a create it never declared is a refusal by construction; the
+ * gate above would already deny it, and this states why rather than relying on
+ * the coincidence.
+ *
+ * Exported for its own tests rather than only exercised through
+ * {@link referenceFieldOptions}: what it returns decides whether a write
+ * affordance for a *second* resource appears, so each gate is worth an
+ * assertion that names it, and the interesting cases (a target needing more
+ * than a name, a denied create) are ones the demo registry does not contain.
+ */
+export async function referenceCreatePlan(
+	ctx: McpContext,
+	table: string,
+	idField: string,
+	display: string | undefined,
+): Promise<ReferenceCreatePlan | undefined> {
+	if (!display) return undefined
+	const entry = ctx.registry.get(table)
+	if (!entry) return undefined
+	const allowed = await canPerformAction(
+		table,
+		entry.config.access,
+		'create',
+		createAccessContext(ctx.user),
+	)
+	if (!allowed) return undefined
+	const serverStamped = new Set(
+		[
+			entry.config.tenantField,
+			entry.config.softDelete ? 'deletedAt' : undefined,
+		]
+			.filter((f): f is string => typeof f === 'string')
+			.concat(display),
+	)
+	const outstanding = requiredCreateFields(entry.resource).filter(
+		(name) => !serverStamped.has(name),
+	)
+	if (outstanding.length > 0) return undefined
+	return { resource: table, idField, labelField: display }
 }
 
 /**

--- a/packages/maxstack-core/src/sprout/validation.ts
+++ b/packages/maxstack-core/src/sprout/validation.ts
@@ -214,6 +214,31 @@ function includeColumn(column: SproutColumn): boolean {
 	return true
 }
 
+/**
+ * The columns a create must name, or the write is refused.
+ *
+ * Derived from the *same* three conditions {@link generateValidationSchema}
+ * applies in create mode — the column is in the input schema at all, and it is
+ * neither nullable-and-not-forced-required nor defaulted-and-not-forced-required
+ * — rather than restated, because the only consumer of this list is code
+ * deciding whether it may mint a record from less than a full form. A second
+ * reading of "required" that drifted optimistic would offer an affordance whose
+ * every use 422s; one that drifted pessimistic would silently withdraw a
+ * capability nobody could then find. The schema is the fact; this reads it out.
+ *
+ * What it does *not* account for is the columns `opCreate` stamps after the
+ * caller is done with the row — the tenant column, the soft-delete column, a
+ * portal's bound. Those are required of the *row* and never of the *caller*, and
+ * they are not knowable from a resource alone, so a caller that needs the
+ * caller-facing set subtracts them itself (`referenceFieldOptions` does).
+ */
+export function requiredCreateFields(resource: SproutResource): string[] {
+	const schema = generateValidationSchema(resource, 'create')
+	return Object.entries(schema.shape)
+		.filter(([, field]) => !field.safeParse(undefined).success)
+		.map(([name]) => name)
+}
+
 export function generateValidationSchema(
 	resource: SproutResource,
 	mode: ValidationMode = 'create',

--- a/packages/ui/src/DynamicForm.tsx
+++ b/packages/ui/src/DynamicForm.tsx
@@ -72,6 +72,7 @@ export {
 	type FormLayout,
 	type FormSection,
 	type InputTypeOverride,
+	type ReferenceFieldPlans,
 	referenceUiOptions,
 	type SectionVariant,
 } from './form/types.ts'

--- a/packages/ui/src/form/FieldRenderer.tsx
+++ b/packages/ui/src/form/FieldRenderer.tsx
@@ -215,6 +215,7 @@ export function FieldRenderer({ config, meta, ctx }: FieldRendererProps) {
 				ariaDescribedBy={meta.errorId}
 				className={uiOptions?.className}
 				onCreate={uiOptions?.onCreateReference}
+				create={uiOptions?.referenceCreate}
 				search={uiOptions?.referenceSearch}
 			/>
 		)
@@ -232,6 +233,7 @@ export function FieldRenderer({ config, meta, ctx }: FieldRendererProps) {
 				ariaDescribedBy={meta.errorId}
 				className={uiOptions?.className}
 				onCreate={uiOptions?.onCreateReference}
+				create={uiOptions?.referenceCreate}
 				search={uiOptions?.referenceSearch}
 			/>
 		)

--- a/packages/ui/src/form/reference-create.test.tsx
+++ b/packages/ui/src/form/reference-create.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * #443 — create-inline in the FK picker was fully built and reachable from
+ * nothing.
+ *
+ * The tests split along the seam the issue draws. The *gates* — may this viewer
+ * create one, is a name enough to make one — are server facts and are tested
+ * where they are decided (`apps/web/app/reference-create.test.ts`). What is
+ * testable here is everything downstream of the answer: a plan produces a
+ * working "Create …" row, no plan produces no row at all, the write goes through
+ * the ordinary provider, and a refusal says so instead of vanishing.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { DataProvider } from '../data/data-context.tsx'
+import type { DataProvider as DataProviderContract } from '../data/data-provider.ts'
+import { createMemoryDataProvider } from '../data/memory-provider.ts'
+import type { IntrospectedColumn } from '../fields/field-semantics.ts'
+import {
+	FormAutocomplete,
+	FormReferenceArrayInput,
+} from '../ui/form-fields.tsx'
+import type { ReferenceCreatePlan } from './reference-create.ts'
+import { referenceUiOptions } from './types.ts'
+
+const PLAN: ReferenceCreatePlan = {
+	resource: 'customer',
+	idField: 'id',
+	labelField: 'name',
+}
+
+const OPTIONS = [{ label: 'Customer 1', value: 'c1' }]
+
+function withData(ui: React.ReactNode, provider?: DataProviderContract) {
+	const dataProvider =
+		provider ?? createMemoryDataProvider({ data: { customer: [] } })
+	return {
+		dataProvider,
+		...render(<DataProvider dataProvider={dataProvider}>{ui}</DataProvider>),
+	}
+}
+
+/** Type a name no loaded option carries, so the create row is the offer. */
+function typeUnmatched(value = 'Northwind') {
+	const box = screen.getByRole('combobox')
+	fireEvent.focus(box)
+	fireEvent.change(box, { target: { value } })
+}
+
+const createRow = () => screen.queryByRole('button', { name: /^Create/ })
+
+describe('the picker offers create only when the server said it may', () => {
+	it('offers it with a plan', () => {
+		withData(
+			<FormAutocomplete name="customerId" options={OPTIONS} create={PLAN} />,
+		)
+		typeUnmatched()
+		expect(createRow()).not.toBeNull()
+	})
+
+	it('does not offer it without one', () => {
+		// The permission half of the issue. A viewer who may pick a customer is not
+		// thereby a viewer who may create one, and the row is *absent* rather than
+		// refused on click — an affordance that promises and then 403s is the shape
+		// #388 exists to stop.
+		withData(<FormAutocomplete name="customerId" options={OPTIONS} />)
+		typeUnmatched()
+		expect(createRow()).toBeNull()
+		expect(screen.getByText('No matches')).toBeTruthy()
+	})
+
+	it('does not offer it with a plan but no data layer to create through', () => {
+		// Degrades exactly as the search does: with nothing to POST to there is no
+		// handler, so there is no row, rather than a row whose click does nothing.
+		render(
+			<FormAutocomplete name="customerId" options={OPTIONS} create={PLAN} />,
+		)
+		typeUnmatched()
+		expect(createRow()).toBeNull()
+	})
+
+	it('does not offer it for a query that already matches exactly', () => {
+		withData(
+			<FormAutocomplete name="customerId" options={OPTIONS} create={PLAN} />,
+		)
+		typeUnmatched('Customer 1')
+		expect(createRow()).toBeNull()
+	})
+})
+
+describe('creating from the picker', () => {
+	it('writes through the ordinary provider and selects what came back', async () => {
+		const { dataProvider, container } = withData(
+			<FormAutocomplete name="customerId" options={OPTIONS} create={PLAN} />,
+		)
+		typeUnmatched()
+		await act(async () => {
+			fireEvent.click(createRow() as HTMLElement)
+		})
+
+		// The record exists, made of the typed string and nothing else.
+		const page = await dataProvider.getList('customer')
+		expect(page.data).toHaveLength(1)
+		expect(page.data[0]?.name).toBe('Northwind')
+
+		// And the form now submits its id — the point of the whole exercise.
+		const hidden = container.querySelector<HTMLInputElement>(
+			'input[type="hidden"][name="customerId"]',
+		)
+		expect(hidden?.value).toBe(String(page.data[0]?.id))
+	})
+
+	it('shows the label the server stored, not the label that was typed', async () => {
+		// A create that trims, normalizes or titlecases would otherwise leave the
+		// picker displaying something the row does not say.
+		const memory = createMemoryDataProvider({ data: { customer: [] } })
+		const normalizing: DataProviderContract = {
+			...memory,
+			create: (resource, data) =>
+				memory.create(resource, { ...data, name: 'NORTHWIND' }),
+		}
+		withData(
+			<FormAutocomplete name="customerId" options={OPTIONS} create={PLAN} />,
+			normalizing,
+		)
+		typeUnmatched()
+		await act(async () => {
+			fireEvent.click(createRow() as HTMLElement)
+		})
+		expect(screen.getByRole('combobox')).toHaveProperty('value', 'NORTHWIND')
+	})
+
+	it('says a refused create was refused, and selects nothing', async () => {
+		// The gates make a refusal here a surprise — a unique-name collision, a
+		// custom validation, an `owner` rule reading the row. Before this issue
+		// nothing awaited the handler, so a rejection was an unhandled rejection and
+		// the picker just sat there looking like the click had missed.
+		const memory = createMemoryDataProvider({ data: { customer: [] } })
+		const refusing: DataProviderContract = {
+			...memory,
+			create: () => Promise.reject(new Error('nope')),
+		}
+		const { container } = withData(
+			<FormAutocomplete name="customerId" options={OPTIONS} create={PLAN} />,
+			refusing,
+		)
+		typeUnmatched()
+		await act(async () => {
+			fireEvent.click(createRow() as HTMLElement)
+		})
+		expect(screen.getByText(/Could not create customer/)).toBeTruthy()
+		const hidden = container.querySelector<HTMLInputElement>(
+			'input[type="hidden"][name="customerId"]',
+		)
+		expect(hidden?.value).toBe('')
+	})
+
+	it('prefers a hand-written onCreate over the derived one', async () => {
+		// Owned code passing `onCreate` is a deliberate statement about how a record
+		// gets made; a plan is a default. The provider must not also be called.
+		const memory = createMemoryDataProvider({ data: { customer: [] } })
+		const onCreate = vi.fn(() => ({ label: 'Mine', value: 'x1' }))
+		const { container } = withData(
+			<FormAutocomplete
+				name="customerId"
+				options={OPTIONS}
+				create={PLAN}
+				onCreate={onCreate}
+			/>,
+			memory,
+		)
+		typeUnmatched()
+		await act(async () => {
+			fireEvent.click(createRow() as HTMLElement)
+		})
+		expect(onCreate).toHaveBeenCalledWith('Northwind')
+		expect((await memory.getList('customer')).data).toHaveLength(0)
+		const hidden = container.querySelector<HTMLInputElement>(
+			'input[type="hidden"][name="customerId"]',
+		)
+		expect(hidden?.value).toBe('x1')
+	})
+
+	it('adds the new record to the selection on the many side', async () => {
+		const { dataProvider, container } = withData(
+			<FormReferenceArrayInput
+				name="tagIds"
+				options={OPTIONS}
+				create={{ ...PLAN, resource: 'tag' }}
+			/>,
+		)
+		typeUnmatched('Urgent')
+		await act(async () => {
+			fireEvent.click(createRow() as HTMLElement)
+		})
+		const created = (await dataProvider.getList('tag')).data[0]
+		expect(created?.name).toBe('Urgent')
+		const hidden = container.querySelectorAll<HTMLInputElement>(
+			'input[type="hidden"][name="tagIds"]',
+		)
+		expect([...hidden].map((i) => i.value)).toEqual([String(created?.id)])
+	})
+})
+
+describe('referenceUiOptions routes the plan to its field', () => {
+	const columns: IntrospectedColumn[] = [
+		{
+			name: 'customerId',
+			type: 'text',
+			references: { table: 'customer', column: 'id', displayField: 'name' },
+		},
+	]
+
+	it('carries the create plan through to the field', () => {
+		const ui = referenceUiOptions(columns, {
+			options: { customerId: OPTIONS },
+			create: { customerId: PLAN },
+		})
+		expect(ui.customerId?.referenceCreate).toEqual(PLAN)
+	})
+
+	it('leaves it undefined for a field the server gave no plan for', () => {
+		// The default, and the safe direction: an FK column with options and no
+		// create plan is one the viewer may read and may not write.
+		const ui = referenceUiOptions(columns, {
+			options: { customerId: OPTIONS },
+			create: {},
+		})
+		expect(ui.customerId?.referenceOptions).toEqual(OPTIONS)
+		expect(ui.customerId?.referenceCreate).toBeUndefined()
+	})
+})

--- a/packages/ui/src/form/reference-create.ts
+++ b/packages/ui/src/form/reference-create.ts
@@ -1,0 +1,101 @@
+/**
+ * Creating the referenced record from inside the FK picker (#443).
+ *
+ * ## What was already there, and why it did nothing
+ *
+ * `<FormAutocomplete>` and `<FormReferenceArrayInput>` have both implemented
+ * create-inline since Plan v5: an unmatched, non-exact query offers a "Create …"
+ * row, an `onCreate` handler mints the option, and it is selected immediately.
+ * `FieldRenderer` wired that handler to `uiOptions.onCreateReference` — and
+ * nothing ever set `onCreateReference`. The capability was reachable from owned
+ * code and dead in every generated app, which is a worse state than absent: it
+ * is a feature nobody who has not read `form/types.ts` knows exists.
+ *
+ * ## The half that could not be derived
+ *
+ * #442 derived the *search* plan from the columns the form already carries, so
+ * no loader had to remember to pass it. Create cannot be derived that way, and
+ * the reason is the point of this module: the two questions that decide whether
+ * the affordance may render at all are facts about a resource **this form is not
+ * for**.
+ *
+ * 1. **May this viewer create one?** Picking a customer and creating a customer
+ *    are different permissions, and a form for an invoice knows neither. Offering
+ *    a "Create …" row that 403s on click is the #388 shape — an affordance that
+ *    promises and then refuses. The row must be *absent*, and only the server can
+ *    say so, via the same `canPerformAction` the write itself will run.
+ * 2. **Can one be made from a name?** Most entities require more than their
+ *    title. Minting from a single string then either fails validation or writes a
+ *    half-record, so the affordance is offered only when every other field the
+ *    target requires at create has a default or is nullable —
+ *    `requiredCreateFields` in core, read from the very schema `opCreate`
+ *    validates against.
+ *
+ * Both are answered once, server-side, in `referenceFieldOptions` — the one
+ * helper all eight loaders already call, which is what keeps this from becoming a
+ * second thing a surface can silently miss.
+ *
+ * ## The write is the ordinary write
+ *
+ * The handler this module builds posts through the `DataProvider` — `POST
+ * /api/:resource` — so the create is `opCreate` on the target resource with its
+ * own authz check, its own audit entry and its own origin attribution. It is not
+ * a side door inheriting the parent form's permission, and, exactly as inline
+ * edit has no inline-edit endpoint, **there is no create-inline endpoint**. If
+ * every gate above were computed wrong, the create would be refused by the same
+ * rule that refuses it on the target's own New form.
+ */
+
+import { useCallback } from 'react'
+import { useOptionalDataProvider } from '../data/data-context.tsx'
+import type { AutocompleteOption } from '../ui/form-fields.tsx'
+
+/** What a picker needs to mint a record of the resource it points at. */
+export interface ReferenceCreatePlan {
+	/** The referenced resource, as the REST surface names it. */
+	resource: string
+	/** The referenced record's id column — the value the picker submits. */
+	idField: string
+	/** The one field the typed string becomes. Everything else the target
+	 * requires at create must default or be nullable, or no plan is built. */
+	labelField: string
+}
+
+/**
+ * The `onCreate` handler for a picker, or `undefined` when it must not offer
+ * one.
+ *
+ * `undefined` — rather than a handler that throws — because the components read
+ * `onCreate`'s presence as "may this row render at all". A handler that existed
+ * and failed would put the affordance on screen and take it back on click, which
+ * is the thing gate 1 exists to prevent.
+ *
+ * With no `<DataProvider>` in context there is no way to reach the target
+ * resource, so there is no handler either. That is the same degradation
+ * `useReferenceSearch` makes, and it means a tree without a data layer behaves
+ * exactly as it did before this module existed.
+ */
+export function useReferenceCreate(
+	plan?: ReferenceCreatePlan,
+): ((label: string) => Promise<AutocompleteOption>) | undefined {
+	const dataProvider = useOptionalDataProvider()
+	const create = useCallback(
+		async (label: string): Promise<AutocompleteOption> => {
+			// Narrowed by the guard below; both are non-null whenever the returned
+			// handler is the one the caller got.
+			if (!plan || !dataProvider) throw new Error('no create plan')
+			const row = await dataProvider.create(plan.resource, {
+				[plan.labelField]: label,
+			})
+			const value = String(row[plan.idField] ?? '')
+			// The server's echo, not the typed string: a create that normalizes,
+			// trims or titlecases its label would otherwise leave the picker showing
+			// something the stored row does not say.
+			const stored = row[plan.labelField]
+			return { label: stored == null ? label : String(stored), value }
+		},
+		[dataProvider, plan],
+	)
+	if (!plan || !dataProvider) return undefined
+	return create
+}

--- a/packages/ui/src/form/reference-search.test.tsx
+++ b/packages/ui/src/form/reference-search.test.tsx
@@ -122,7 +122,10 @@ describe('referenceUiOptions', () => {
 				references: { table: 'customer', column: 'id', displayField: 'name' },
 			},
 		]
-		const ui = referenceUiOptions(columns, { customerId: page() })
+		const ui = referenceUiOptions(columns, {
+			options: { customerId: page() },
+			create: {},
+		})
 		expect(ui.customerId?.inputType).toBe('reference')
 		expect(ui.customerId?.referenceSearch).toEqual(PLAN)
 	})
@@ -131,7 +134,10 @@ describe('referenceUiOptions', () => {
 		// The options map and the columns can disagree (a spec/DB skew). No column,
 		// no derived plan — the picker falls back to its page rather than guessing
 		// a resource name.
-		const ui = referenceUiOptions([], { customerId: page() })
+		const ui = referenceUiOptions([], {
+			options: { customerId: page() },
+			create: {},
+		})
 		expect(ui.customerId?.referenceSearch).toBeUndefined()
 	})
 })

--- a/packages/ui/src/form/types.ts
+++ b/packages/ui/src/form/types.ts
@@ -3,6 +3,7 @@
 import type { IntrospectedColumn } from '../fields/field-semantics.ts'
 import type { AutocompleteOption } from '../ui/form-fields.tsx'
 import type { FieldWidget } from '../zod-to-form-fields.ts'
+import type { ReferenceCreatePlan } from './reference-create.ts'
 import {
 	type ReferenceSearchPlan,
 	referenceSearchPlan,
@@ -49,10 +50,43 @@ export interface FieldUiOptions {
 	 * {@link referenceUiOptions}.
 	 */
 	referenceSearch?: ReferenceSearchPlan
-	/** Create-inline handler for the FK picker (mints + selects a new option). */
+	/**
+	 * What the picker needs to create a record of the referenced resource from
+	 * the typed string, and — by its mere presence — permission to offer the
+	 * affordance at all (#443). Built server-side by `referenceFieldOptions`,
+	 * which is the only place the two gates can be answered; absent means the
+	 * viewer may not create one, or the target needs more than a name.
+	 */
+	referenceCreate?: ReferenceCreatePlan
+	/**
+	 * Create-inline handler for the FK picker (mints + selects a new option).
+	 *
+	 * An override for owned code that wants its own minting — a wizard, a
+	 * duplicate check, a default beyond the label. Generated apps get their
+	 * handler from {@link referenceCreate} instead, and this stays undefined;
+	 * when both are present this one wins, because a hand-written handler is a
+	 * deliberate statement and a derived one is a default.
+	 */
 	onCreateReference?: (
 		label: string,
 	) => Promise<AutocompleteOption> | AutocompleteOption
+}
+
+/**
+ * Everything a loader resolves about one resource's FK columns: the first page
+ * of choices for each, and — for the subset that may be created inline — the
+ * plan to do it.
+ *
+ * One object rather than two arguments, deliberately. `onCreateReference` was
+ * dead for a year because it was an optional extra a loader could decline to
+ * pass and nothing would look wrong; a second optional argument to
+ * {@link referenceUiOptions} would rebuild that trap exactly. Threading both
+ * through one value the eight loaders already produce means the compiler asks
+ * for the create half at every site that produces the options half.
+ */
+export interface ReferenceFieldPlans {
+	options: Record<string, AutocompleteOption[]>
+	create: Record<string, ReferenceCreatePlan>
 }
 
 /**
@@ -67,23 +101,30 @@ export interface FieldUiOptions {
  * display field — already travels with the introspection every one of these
  * routes hands the form, so deriving it means the eight loaders that build
  * `referenceOptions` need no change and, more to the point, cannot be the place
- * a surface silently misses out on it. That is the failure mode #443 records:
- * `onCreateReference` is a real capability that no loader ever passes.
+ * a surface silently misses out on it. That was the failure mode #443 recorded:
+ * `onCreateReference` was a real capability that no loader ever passed.
+ *
+ * The **create** plan (#443) cannot be derived here for the reason set out in
+ * `reference-create.ts` — whether the viewer may create a record of the *target*
+ * resource, and whether a name is enough to make one, are facts about a resource
+ * the form does not carry. So it arrives with the options, in one value, and
+ * this function only routes it to the right field.
  */
 export function referenceUiOptions(
 	columns: readonly IntrospectedColumn[],
-	referenceOptions: Record<string, AutocompleteOption[]>,
+	references: ReferenceFieldPlans,
 ): Record<string, FieldUiOptions> {
 	const byName = new Map(columns.map((c) => [c.name, c]))
 	const arrayRefFields = new Set(
 		columns.filter((c) => c.meta?.arrayReference).map((c) => c.name),
 	)
 	const out: Record<string, FieldUiOptions> = {}
-	for (const [field, options] of Object.entries(referenceOptions)) {
+	for (const [field, options] of Object.entries(references.options)) {
 		const column = byName.get(field)
 		out[field] = {
 			inputType: arrayRefFields.has(field) ? 'reference-array' : 'reference',
 			referenceOptions: options,
+			referenceCreate: references.create[field],
 			referenceSearch: column ? referenceSearchPlan(column) : undefined,
 		}
 	}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -45,6 +45,7 @@ export type {
 	FormLayout,
 	FormSection,
 	InputTypeOverride,
+	ReferenceFieldPlans,
 	SectionVariant,
 } from './DynamicForm.tsx'
 export { DynamicForm, referenceUiOptions } from './DynamicForm.tsx'
@@ -193,6 +194,10 @@ export {
 	formatDateTyping,
 	isCompleteDate,
 } from './form/DateInput.tsx'
+export {
+	type ReferenceCreatePlan,
+	useReferenceCreate,
+} from './form/reference-create.ts'
 export {
 	REFERENCE_OPTION_PAGE,
 	type ReferenceSearchPlan,

--- a/packages/ui/src/ui/form-fields.tsx
+++ b/packages/ui/src/ui/form-fields.tsx
@@ -18,6 +18,10 @@ import { Select } from '@base-ui/react/select'
 import { useControl } from '@conform-to/react/future'
 import { useId, useMemo, useRef, useState } from 'react'
 import {
+	type ReferenceCreatePlan,
+	useReferenceCreate,
+} from '../form/reference-create.ts'
+import {
 	REFERENCE_OPTION_PAGE,
 	type ReferenceSearchPlan,
 	useReferenceSearch,
@@ -180,8 +184,10 @@ export interface AutocompleteOption {
  * Conform exactly like `FormSelect`: `useControl` owns the submitted value and a
  * hidden `<input name>` is registered, so exactly one id submits per field.
  *
- * With `onCreate` an unmatched query offers a "Create" row that mints a new
- * option inline (react-admin's create-inline) and selects it.
+ * With `create` — the server having said this viewer may create one and that a
+ * name is enough to make one — an unmatched query offers a "Create" row that
+ * mints the record through the ordinary `POST /api/:resource` and selects it
+ * (#443). `onCreate` is the owned-code override of the same row.
  *
  * With `search` — and a `<DataProvider>` in context — a query goes to the
  * referenced resource instead of filtering `options`, which is only ever the
@@ -196,16 +202,23 @@ export function FormAutocomplete({
 	ariaDescribedBy,
 	className,
 	onCreate,
+	create: createPlan,
 	search,
 }: FieldWidgetProps & {
 	options: AutocompleteOption[]
 	defaultValue?: string
 	placeholder?: string
 	onCreate?: (label: string) => Promise<AutocompleteOption> | AutocompleteOption
+	create?: ReferenceCreatePlan
 	search?: ReferenceSearchPlan
 }) {
 	const control = useControl({ defaultValue })
 	const [extra, setExtra] = useState<AutocompleteOption[]>([])
+	const derivedCreate = useReferenceCreate(createPlan)
+	// The hand-written handler wins: a plan is a default, and owned code passing
+	// `onCreate` is a deliberate statement about how a record gets made.
+	const mint = onCreate ?? derivedCreate
+	const [createFailed, setCreateFailed] = useState(false)
 	const all = useMemo(() => [...options, ...extra], [options, extra])
 	const selected = control.value ?? ''
 
@@ -254,11 +267,25 @@ export function FormAutocomplete({
 		setOpen(false)
 	}
 
+	/**
+	 * Mint the record and select it — or say that it did not happen.
+	 *
+	 * The gates mean a refusal here is a surprise (a unique-name collision, a
+	 * custom validation, a rule that reads the row), and a surprise is exactly
+	 * the case that must not be swallowed: before #443 nothing awaited this, so a
+	 * rejected handler was an unhandled rejection and the picker simply sat
+	 * there. Nothing is selected on failure, so there is no half-state to undo.
+	 */
 	async function create() {
-		if (!onCreate) return
-		const created = await onCreate(query.trim())
-		setExtra((prev) => [...prev, created])
-		choose(created)
+		if (!mint) return
+		setCreateFailed(false)
+		try {
+			const created = await mint(query.trim())
+			setExtra((prev) => [...prev, created])
+			choose(created)
+		} catch {
+			setCreateFailed(true)
+		}
 	}
 
 	// While open the input shows the live query; when closed it shows the
@@ -321,7 +348,7 @@ export function FormAutocomplete({
 							Could not search {search?.resource ?? 'records'} — try again
 						</p>
 					)}
-					{filtered.length === 0 && !onCreate && !searching && !failed && (
+					{filtered.length === 0 && !mint && !searching && !failed && (
 						<p className="px-2 py-1.5 text-muted-foreground">No matches</p>
 					)}
 					{/* The loader sends one page. With a full page there is no way to
@@ -334,7 +361,7 @@ export function FormAutocomplete({
 								: `Showing the first ${REFERENCE_OPTION_PAGE}`}
 						</p>
 					)}
-					{onCreate && query.trim() && !exactMatch && (
+					{mint && query.trim() && !exactMatch && (
 						<button
 							type="button"
 							onMouseDown={(e) => e.preventDefault()}
@@ -346,6 +373,12 @@ export function FormAutocomplete({
 						>
 							Create “{query.trim()}”
 						</button>
+					)}
+					{createFailed && (
+						<p className="px-2 py-1.5 text-destructive">
+							Could not create {createPlan?.resource ?? 'the record'} — nothing
+							was saved
+						</p>
 					)}
 				</div>
 			)}
@@ -402,8 +435,9 @@ export function FormMultiCheckboxGroup({
  * a `string[]` for `z.array(z.string())`, exactly like `FormMultiCheckboxGroup`.
  * No Conform `useControl` needed: the submitted shape is native.
  *
- * With `onCreate` an unmatched query offers a create-inline row (react-admin's
- * pattern), minting a new option and selecting it.
+ * `create` and `onCreate` are the single picker's create-inline, unchanged in
+ * meaning (#443): an unmatched query offers a row that mints the record through
+ * `POST /api/:resource` and adds it to the selection.
  *
  * `search` gives it the same server-side query as the single picker (#442). A
  * chip whose label is not in the loaded page falls back to the id — ugly and
@@ -418,16 +452,21 @@ export function FormReferenceArrayInput({
 	ariaDescribedBy,
 	className,
 	onCreate,
+	create: createPlan,
 	search,
 }: FieldWidgetProps & {
 	options: AutocompleteOption[]
 	defaultValue?: string[]
 	placeholder?: string
 	onCreate?: (label: string) => Promise<AutocompleteOption> | AutocompleteOption
+	create?: ReferenceCreatePlan
 	search?: ReferenceSearchPlan
 }) {
 	const [selected, setSelected] = useState<string[]>(defaultValue)
 	const [extra, setExtra] = useState<AutocompleteOption[]>([])
+	const derivedCreate = useReferenceCreate(createPlan)
+	const mint = onCreate ?? derivedCreate
+	const [createFailed, setCreateFailed] = useState(false)
 	const all = useMemo(() => [...options, ...extra], [options, extra])
 	const labelFor = (value: string) =>
 		all.find((o) => o.value === value)?.label ?? value
@@ -465,11 +504,17 @@ export function FormReferenceArrayInput({
 	function remove(value: string) {
 		setSelected((prev) => prev.filter((v) => v !== value))
 	}
+	/** As `FormAutocomplete`'s: a refusal is reported, and adds nothing. */
 	async function create() {
-		if (!onCreate) return
-		const created = await onCreate(query.trim())
-		setExtra((prev) => [...prev, created])
-		add(created.value)
+		if (!mint) return
+		setCreateFailed(false)
+		try {
+			const created = await mint(query.trim())
+			setExtra((prev) => [...prev, created])
+			add(created.value)
+		} catch {
+			setCreateFailed(true)
+		}
 	}
 
 	return (
@@ -548,7 +593,7 @@ export function FormReferenceArrayInput({
 								Could not search {search?.resource ?? 'records'} — try again
 							</p>
 						)}
-						{available.length === 0 && !onCreate && !searching && !failed && (
+						{available.length === 0 && !mint && !searching && !failed && (
 							<p className="px-2 py-1.5 text-muted-foreground">No matches</p>
 						)}
 						{pageIsFull && !searching && (
@@ -558,7 +603,7 @@ export function FormReferenceArrayInput({
 									: `Showing the first ${REFERENCE_OPTION_PAGE}`}
 							</p>
 						)}
-						{onCreate && query.trim() && !exactMatch && (
+						{mint && query.trim() && !exactMatch && (
 							<button
 								type="button"
 								onMouseDown={(e) => e.preventDefault()}
@@ -570,6 +615,12 @@ export function FormReferenceArrayInput({
 							>
 								Create “{query.trim()}”
 							</button>
+						)}
+						{createFailed && (
+							<p className="px-2 py-1.5 text-destructive">
+								Could not create {createPlan?.resource ?? 'the record'} —
+								nothing was saved
+							</p>
 						)}
 					</div>
 				)}


### PR DESCRIPTION
`<FormAutocomplete>` and `<FormReferenceArrayInput>` have implemented
create-inline since Plan v5: an unmatched, non-exact query offers a
"Create …" row, `onCreate` mints the option, and it is selected
immediately. `FieldRenderer` wired that handler to
`uiOptions.onCreateReference` — and nothing ever set
`onCreateReference`. Zero callers, in the whole tree. The capability was
reachable from owned code and dead in every generated app, which is a
worse state than absent: a feature nobody who has not read
`form/types.ts` knows exists.

Wiring the prop was never the work. Creating the referenced record is a
write to a *second* resource from inside a form for the first, and it has
to answer what #417 already answered for actions rather than inventing
new answers:

- it is `opCreate` on the target through the ordinary `DataProvider` —
  `POST /api/:resource` — so its own authz check, its own audit entry,
  its own origin attribution. Not a side door inheriting the parent
  form's permission. As inline edit has no inline-edit endpoint, there is
  no create-inline endpoint: if every gate below were computed wrong, the
  write would be refused by the rule that refuses it on the target's own
  New form.
- a viewer who may pick a customer is not thereby a viewer who may create
  one, so the row is **absent** when the create permission is not held,
  not refused on click.
- most entities require more than a title, so minting from one string
  either 422s or writes a half-record. The offer stands only when every
  other field the target requires at create defaults or is nullable.

Both gates are facts about a resource the form is not for, so unlike
#442's search plan they cannot be derived on the client. They are
answered once in `referenceFieldOptions` — the one server helper all
eight loaders already call — and travel *with* the options in one value
rather than as a second optional argument, because an optional extra a
loader may decline to pass is exactly how `onCreateReference` stayed dead
for a year. The compiler now asks for the create half everywhere the
options half is produced.

The required-at-create set is read from the create schema itself
(`requiredCreateFields`, new in core) rather than restated, minus the
columns `opCreate` stamps after the caller is done — the tenant column
and the soft-delete column are required of the row and never of the
caller, and counting them would withdraw create-inline from every
org-scoped resource in the product.

Also: a rejected create is now reported. Nothing awaited the handler
before, so a refusal was an unhandled rejection and the picker sat there
looking like the click had missed. Nothing is selected on failure, so
there is no half-state to undo.

Closes sys13/maxstack-internal#443

🤖 Generated with [Claude Code](https://claude.com/claude-code)